### PR TITLE
remove the extra & in the generated query parameter string.

### DIFF
--- a/src/AbstractPersonalityInsights.php
+++ b/src/AbstractPersonalityInsights.php
@@ -152,7 +152,7 @@ abstract class AbstractPersonalityInsights implements InsightsContract
 
         // We have something in the result.
         if (! empty($finalQueryString)) {
-            rtrim($finalQueryString, '&');
+            $finalQueryString = rtrim($finalQueryString, '&');
         }
 
         // We return our results.


### PR DESCRIPTION
remove the extra '&' in generate query parameter string as specified in #8 